### PR TITLE
Add portfolio tracker link

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
       <a href="https://uriapkm.github.io/Parke-Print&Design/" target="_blank">🛠️ Parke Print & Design</a><br>
       <a href="https://uriapkm.github.io/RP-portfolio/" target="_blank">🔬 RP Portfolio</a><br>
       <a href="https://uriapkm.github.io/web-creator/" target="_blank">🤖 AI Web Creator</a><br>
+      <a href="https://uriapkm.github.io/cartera-activos/" target="_blank">📈 Seguimiento de Cartera</a><br>
       <a href="https://uriapkm.github.io/digital-preppernaut/" target="_blank">🎮 Digital Preppernaut</a>
     </div>
 


### PR DESCRIPTION
## Summary
- link the portfolio tracker from the landing page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ff14106f883218aec70ee940ca61d