### PR TITLE
Improve Shadowfax page visuals

### DIFF
--- a/Shadowfax-Prototyping/index.html
+++ b/Shadowfax-Prototyping/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="./assets/logo.svg" type="image/svg+xml" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -22,7 +22,7 @@
       <a href="#gallery">Gallery</a>
       <a href="#contact">Contact</a>
     </nav>
-    <h1>Shadowfax Prototyping</h1>
+    <h1 class="sr-only">Shadowfax Prototyping</h1>
     <p class="tagline">Mobile CAD & 3D Printing Solutions - We Come to You</p>
     <blockquote>"Show them the meaning of haste."</blockquote>
   </header>

--- a/Shadowfax-Prototyping/style.css
+++ b/Shadowfax-Prototyping/style.css
@@ -5,15 +5,34 @@ body {
   color: #222;
 }
 
+/* Utility class to hide elements visually while keeping them for screen readers */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .hero {
-  background: linear-gradient(120deg, #2c5364, #203a43, #0f2027);
+  background: linear-gradient(120deg, #4e54c8, #203a43);
   color: #fff;
   text-align: center;
   padding: 3rem 1rem;
 }
+.hero h1 {
+  font-family: 'Poppins', sans-serif;
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+}
 
 .logo {
-  width: 60px;
+  width: 150px;
   height: auto;
 }
 
@@ -28,16 +47,19 @@ body {
   color: #fff;
   text-decoration: none;
   font-weight: bold;
+  transition: color 0.2s ease;
 }
 
 .main-nav a:hover {
   text-decoration: underline;
+  color: #e1ecf1;
 }
 
 .tagline {
-  font-size: 1.2rem;
+  font-size: 1.3rem;
   margin-bottom: 1rem;
   font-weight: 400;
+  color: #f0f0f0;
 }
 
 main {
@@ -46,9 +68,27 @@ main {
   padding: 2rem;
 }
 
+.intro,
+.industries,
+.workflow {
+  margin-bottom: 2rem;
+}
+
+.intro {
+  background-color: #ffffff;
+  padding: 1rem 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.workflow ol {
+  padding-left: 1.2rem;
+}
+
 h2 {
   color: #203a43;
   margin-top: 0;
+  font-family: 'Poppins', sans-serif;
 }
 
 .services ul {
@@ -64,6 +104,7 @@ h2 {
   border-radius: 6px;
   padding: 0.5rem 1rem;
   flex: 1 1 200px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .gallery-grid {
@@ -74,17 +115,22 @@ h2 {
 
 .gallery-grid figure {
   margin: 0;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
 }
 
 .gallery-grid img {
   width: 100%;
-  border-radius: 8px;
+  display: block;
 }
 
 .gallery-grid figcaption {
   text-align: center;
   font-size: 0.9rem;
   margin-top: 0.25rem;
+  font-weight: 500;
 }
 
 footer {
@@ -107,6 +153,8 @@ blockquote {
   color: #fff;
   text-decoration: none;
   border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: background-color 0.2s ease;
 }
 
 .cta-button:hover {
@@ -127,4 +175,5 @@ blockquote {
 
 .viewer iframe {
   border: none;
+  margin-top: 1rem;
 }


### PR DESCRIPTION
## Summary
- restyle hero section with lighter gradient
- load Poppins font and use for headers
- enlarge logo and tagline for better visibility
- add spacing and soft shadows to content sections
- improve gallery and CTA button styles
- enlarge hero logo and hide duplicate heading text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68403d2e2b4c83218e45c64b39c52354